### PR TITLE
Reflow tune selection to be more pythonic

### DIFF
--- a/rickroll.py
+++ b/rickroll.py
@@ -123,11 +123,11 @@ def original():
         return str(play_menu())
 
     # Otherwise load the song they want, with a default of the original
-    # song if they select something outsie our array bounds.
-    tune = _original
-
-    try: tune = tunes[selection]
-    except Exception: pass
+    # song if they select something outside our array bounds.
+    try:
+        tune = tunes[selection]
+    except IndexError:
+        tune = _original
 
     return str(play_tune(tune))
 


### PR DESCRIPTION
Variables in Python are not unreachable when they drop out of scope,
which means that variables do not need to be defined before a try/except
block, but can be done so inside it. Further, tighten the exception to
be IndexError rather than the generic Exception, and correct a typo in
the comment above the block.